### PR TITLE
Fix missing token after reload

### DIFF
--- a/src/helpers/loaders/rootLoader.js
+++ b/src/helpers/loaders/rootLoader.js
@@ -9,6 +9,8 @@ export default function rootLoader() {
     //store spotify token on local storage
     localStorage.setItem("token", spotifyToken);
     spotifyApi.setAccessToken(spotifyToken);
+  } else {
+    spotifyApi.setAccessToken(localStorage.getItem("token"));
   }
 
   return spotifyApi;


### PR DESCRIPTION
Fixes the issue that API calls are unauthenticated in case the app is opened or reloaded although the user is logged in.

The root loader is supposed to provide an instance of the Spotify API library with an access token set. This change implements the setting of the token from local storage in case we're not being redirected from the login.